### PR TITLE
adding deepseekOCR

### DIFF
--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -35,6 +35,7 @@ def test_convert(file_path, model):
         "paddleocrvl",
         "mineru25",
         "chandra",
+        "deepseekocr",
     ],
 )
 def test_convert_with_docker(file_path, model):

--- a/vlmparse/clients/deepseekocr.py
+++ b/vlmparse/clients/deepseekocr.py
@@ -1,0 +1,48 @@
+from pydantic import Field
+
+from vlmparse.clients.openai_converter import OpenAIConverterConfig
+from vlmparse.servers.docker_server import VLLMDockerServerConfig
+
+
+class DeepSeekOCRDockerServerConfig(VLLMDockerServerConfig):
+    """Configuration for DeepSeekOCR model."""
+
+    model_name: str = "deepseek-ai/DeepSeek-OCR"
+    command_args: list[str] = Field(
+        default_factory=lambda: [
+            "--limit-mm-per-prompt",
+            '{"image": 1}',
+            "--async-scheduling",
+            "--logits_processors",
+            "vllm.model_executor.models.deepseek_ocr:NGramPerReqLogitsProcessor",
+            "--no-enable-prefix-caching",
+            "--mm-processor-cache-gb",
+            "0",
+        ]
+    )
+
+    @property
+    def client_config(self):
+        return DeepSeekOCRConverterConfig(llm_params=self.llm_params)
+
+
+class DeepSeekOCRConverterConfig(OpenAIConverterConfig):
+    """DeepSeekOCR converter - backward compatibility alias."""
+
+    preprompt: str | None = None
+    postprompt: str | None = "<|grounding|>Convert the document to markdown."
+    completion_kwargs: dict | None = {
+        "temperature": 0.0,
+        "extra_body": {
+            "skip_special_tokens": False,
+            # args used to control custom logits processor
+            "vllm_xargs": {
+                "ngram_size": 30,
+                "window_size": 90,
+                # whitelist: <td>, </td>
+                "whitelist_token_ids": [128821, 128822],
+            },
+        },
+    }
+    max_image_size: int | None = 1540
+    dpi: int = 200

--- a/vlmparse/registries.py
+++ b/vlmparse/registries.py
@@ -2,6 +2,10 @@ import os
 from collections.abc import Callable
 
 from vlmparse.clients.chandra import ChandraConverterConfig, ChandraDockerServerConfig
+from vlmparse.clients.deepseekocr import (
+    DeepSeekOCRConverterConfig,
+    DeepSeekOCRDockerServerConfig,
+)
 from vlmparse.clients.docling import DoclingConverterConfig, DoclingDockerServerConfig
 from vlmparse.clients.dotsocr import DotsOCRConverterConfig, DotsOCRDockerServerConfig
 from vlmparse.clients.hunyuanocr import (
@@ -46,6 +50,7 @@ docker_config_registry.register(
 docker_config_registry.register("olmocr-2-fp8", lambda: OlmOCRDockerServerConfig())
 
 docker_config_registry.register("mineru25", lambda: MinerUDockerServerConfig())
+docker_config_registry.register("deepseekocr", lambda: DeepSeekOCRDockerServerConfig())
 
 
 class ConverterConfigRegistry:
@@ -173,6 +178,16 @@ converter_config_registry.register(
 converter_config_registry.register(
     "hunyuanocr",
     lambda uri=None: HunyuanOCRConverterConfig(
+        llm_params=LLMParams(
+            base_url=uri or "http://localhost:8000/v1",
+            model_name=DEFAULT_MODEL_NAME,
+            api_key="",
+        )
+    ),
+)
+converter_config_registry.register(
+    "deepseekocr",
+    lambda uri=None: DeepSeekOCRConverterConfig(
         llm_params=LLMParams(
             base_url=uri or "http://localhost:8000/v1",
             model_name=DEFAULT_MODEL_NAME,


### PR DESCRIPTION
Pytest OK

PASSED

============================================================================= warnings summary ==============================================================================
vlmparse/servers/docker_server.py:10
  /home/ldap/vdupriez/vlmparse/vlmparse/servers/docker_server.py:10: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.12/migration/
    class DockerServerConfig(BaseModel):

tests/test_end2end.py: 32 warnings
  /home/ldap/vdupriez/vlmparse/vlmparse/clients/pipe_utils/html_to_md_conversion.py:35: DeprecationWarning: convert_to_markdown() is deprecated and will be removed in v3.0. Use html_to_markdown.convert() with ConversionOptions instead.
    md_txt = convert_to_markdown(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 1 passed, 33 warnings in 174.78s (0:02:54) =================================================================